### PR TITLE
Check for correct $wp_db_version

### DIFF
--- a/includes/login-functions.php
+++ b/includes/login-functions.php
@@ -246,7 +246,7 @@ function rcp_retrieve_password() {
 		require_once ABSPATH . WPINC . '/class-phpass.php';
 		$wp_hasher = new PasswordHash( 8, true );
 	}
-	if ($wp_db_version >= 31536) {
+	if ($wp_db_version >= 32814) {
 		// 4.3 or later
 		$hashed = time() . ':' . $wp_hasher->HashPassword( $key );
 	} else {


### PR DESCRIPTION
`31536` is still on the `4.2` branch: https://github.com/WordPress/WordPress/blob/4.2.3/wp-includes/version.php#L14

The changes to the activation key hash format came in https://github.com/WordPress/WordPress/commit/c261ad2c57fe25e8d49b2f48b40e7fb128dfa897, at which point the db version was `32814`.
